### PR TITLE
cleanup: disable support for arm64 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,28 +7,25 @@ on:
 
 jobs:
   test:
-    name: test-${{ matrix.arch }}
-    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
+    name: test-x86
+    runs-on: ubuntu-24.04
     steps:
-      - name: Install deps
+      # todo!: install a fixed version of virtme-ng
+      - name: Install vng
         run: |
-          sudo apt update
-          sudo apt install --yes git qemu-kvm udev iproute2 busybox-static coreutils python3-requests libvirt-clients kbd kmod file rsync zstd udev 
-          # python3-pip flake8 pylint cargo rustc qemu-system-x86
+          sudo apt update -y
+          sudo apt install -y git qemu-kvm kmod virtiofsd udev virtme-ng
 
-      - name: "KVM support"
+      - name: KVM support
+        if: matrix.arch == 'amd64'
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # todo!: install a fixed version of virtme-ng
-      - name: Install vng
+      - name: Test vng
         run: |
-          sudo apt install virtme-ng
+          vng -v -r v5.4.293 -- /usr/bin/echo "OK"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bpfvalidator
 
-This is a simple tool that spawns qemu machines to test a specific binary on these machines.
+This is a simple tool that spawns qemu machines to test a specific binary on these machines. This is particularly useful for testing eBPF programs against different kernel versions.
 Under the hood it uses [virtme-ng](https://github.com/arighi/virtme-ng) tool to create qemu instancies.
 Given this configuration file:
 
@@ -62,8 +62,8 @@ Example
 
 ```txt
 - v7.9.0 🟡 #the provided machine doesn't exists
-- v5.10.237 🟢
-- v5.15.182 🟢
+- v5.10.237 🟢 # success
+- v5.15.182 🔴 # failure
 ```
 
 ## Build and run

--- a/main_test.go
+++ b/main_test.go
@@ -80,9 +80,9 @@ func TestOutput(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			results := run(tt.cfg)
-			require.Len(t, results, len(tt.resultsExpected), "results length mismatch")
-			require.Equal(t, results[0].version, tt.resultsExpected[0].version, "version mismatch")
-			require.Equal(t, results[0].res, tt.resultsExpected[0].res, "code mismatch.")
+			require.Equal(t, len(tt.resultsExpected), len(results), "results length mismatch")
+			require.Equal(t, tt.resultsExpected[0].version, results[0].version, "version mismatch")
+			require.Equal(t, tt.resultsExpected[0].res, results[0].res, "code mismatch.")
 			if results[0].message != "" {
 				// only in case of failure
 				t.Logf("message from '%s': %s", results[0].version, results[0].message)


### PR DESCRIPTION
Running virtme-ng on arm64 GitHub runners without KVM takes too long, so disable it for now.
Notes on KVM not supported on arm64 runners: https://github.com/orgs/community/discussions/19197#discussioncomment-11863501