### PR TITLE
feat!: add support for providing custom vng arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,17 @@ parallel: 1
 out_path: ""
 # show only the final report and not the individual VM outputs
 report_only: false
-# kernel versions to test
-kernel_versions:
-    - v5.4.293
-    - v5.10.237
-    - v5.15.182
+# VMs configuration
+vm_configs:
+  - v5.4.293
+  - kernel_version: v5.10.237
+    vng_args: "--memory 2G"
+  - v5.15.182
 ```
 
 `bpfvalidator` will:
 
-- create 3 qemu machines with the kernel versions specified in the configuration file
+- create 3 qemu machines with the kernel versions and vng arguments (if any) specified in the configuration file
 - run the command `/usr/bin/echo 'hey'` in each of them
 - wait for the command to finish
 - collect the output of the command

--- a/config.go
+++ b/config.go
@@ -19,8 +19,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 
+	"github.com/go-viper/mapstructure/v2"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -34,7 +36,8 @@ const (
 	keyParallel       = "parallel"
 	keyOutPath        = "out_path"
 	keyReportOnly     = "report_only"
-	keyKernelVersions = "kernel_versions"
+	keyKernelVersions = "kernel_versions" // Only used as CLI argument.
+	keyVMConfigs      = "vm_configs"      // Only used in YAML configuration parsing.
 
 	defaultConfigPath = "./config.yaml"
 	defaultVngPath    = "vng" // assuming vng is in PATH
@@ -44,13 +47,18 @@ const (
 	defaultReportOnly = false
 )
 
+type VMConfig struct {
+	KernelVersion string `mapstructure:"kernel_version"`
+	VngArgs       string `mapstructure:"vng_args"`
+}
+
 type Config struct {
-	VngPath        string   `mapstructure:"vng_path"`
-	Cmd            string   `mapstructure:"cmd"`
-	Parallel       int      `mapstructure:"parallel"`
-	OutPath        string   `mapstructure:"out_path"`
-	ReportOnly     bool     `mapstructure:"report_only"`
-	KernelVersions []string `mapstructure:"kernel_versions"`
+	VngPath    string     `mapstructure:"vng_path"`
+	Cmd        string     `mapstructure:"cmd"`
+	Parallel   int        `mapstructure:"parallel"`
+	OutPath    string     `mapstructure:"out_path"`
+	ReportOnly bool       `mapstructure:"report_only"`
+	VMConfigs  []VMConfig `mapstructure:"vm_configs"`
 }
 
 // fileExists checks if the given path exists and is accessible
@@ -68,8 +76,8 @@ func fileExists(path string) bool {
 }
 
 func (cfg *Config) String() string {
-	return fmt.Sprintf(`Config{VngPath: "%s", Cmd: "%s", Parallel: %d, OutPath: "%s", ReportOnly: %t, KernelVersions: %v}`,
-		cfg.VngPath, cfg.Cmd, cfg.Parallel, cfg.OutPath, cfg.ReportOnly, cfg.KernelVersions)
+	return fmt.Sprintf(`Config{VngPath: "%s", Cmd: "%s", Parallel: %d, OutPath: "%s", ReportOnly: %t, VMConfigs: %+v}`,
+		cfg.VngPath, cfg.Cmd, cfg.Parallel, cfg.OutPath, cfg.ReportOnly, cfg.VMConfigs)
 }
 
 func (cfg *Config) validateConfig() error {
@@ -86,10 +94,35 @@ func (cfg *Config) validateConfig() error {
 		return fmt.Errorf("tested binary not found at '%s'", parts[0])
 	}
 
-	if len(cfg.KernelVersions) == 0 {
-		return fmt.Errorf("'kernel_versions' cannot be empty")
+	if len(cfg.VMConfigs) == 0 {
+		return fmt.Errorf("VMs configuration list cannot be empty")
 	}
 	return nil
+}
+
+// decodeVMConfig is a mapstructure.DecodeHookFunc allowing to unmarshal a VMConfig.
+func decodeVMConfig(fromType, toType reflect.Type, from any) (any, error) {
+	if toType != reflect.TypeOf(VMConfig{}) {
+		return from, nil
+	}
+
+	vmCfg := &VMConfig{}
+	switch fromType.Kind() {
+	case reflect.String:
+		version, ok := from.(string)
+		if !ok {
+			return nil, fmt.Errorf("'version' must be a string")
+		}
+		vmCfg.KernelVersion = version
+	case reflect.Struct:
+		if err := mapstructure.Decode(from, vmCfg); err != nil {
+			return nil, fmt.Errorf("error decoding VM configuration: %w", err)
+		}
+	default:
+		return from, nil
+	}
+
+	return vmCfg, nil
 }
 
 func setupConfig() *Config {
@@ -113,6 +146,12 @@ func setupConfig() *Config {
 		log.Fatalf("Error binding flags: %v", err)
 	}
 
+	// Before checking if a config file was provided as CLI argument, bind `vm_configs` key to `kernel_versions`, so
+	// that the list of kernel versions will override VMs configuration on the config file.
+	if err := viper.BindPFlag(keyVMConfigs, pflag.Lookup(keyKernelVersions)); err != nil {
+		log.Fatalf("Error binding %s key to %s flag: %v", keyVMConfigs, keyKernelVersions, err)
+	}
+
 	// Check if config file exists
 	configFile := viper.GetString(keyConfigPath)
 	viper.SetConfigFile(configFile)
@@ -123,7 +162,13 @@ func setupConfig() *Config {
 	}
 
 	var cfg Config
-	if err := viper.Unmarshal(&cfg); err != nil {
+	if err := viper.Unmarshal(&cfg, viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
+		// Default hooks.
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+		// Custom hooks.
+		decodeVMConfig,
+	))); err != nil {
 		log.Fatalf("cannot unmarshal config in struct: %v", err)
 	}
 

--- a/config.yaml
+++ b/config.yaml
@@ -20,10 +20,11 @@ cmd: "/usr/bin/echo 'hey'"
 parallel: 2
 # Path to the output file for the report (if empty uses stdout)
 out_path: ""
-# show only the final report and not the individual VM outputs
+# Show only the final report and not the individual VM outputs
 report_only: false
-# kernel versions to test
-kernel_versions:
+# VMs configuration
+vm_configs:
     - v5.15.197
-    - v6.1.159
+    - kernel_version: v6.1.159
+      vng_args: "--memory 500M"
     - v6.6.119

--- a/main.go
+++ b/main.go
@@ -58,9 +58,23 @@ func (r result) String() string {
 	return fmt.Sprintf("%s -> version: %s, message: '%s'", convertResToIcon(r.res), r.version, r.message)
 }
 
+// buildVngCmdline builds vng command line.
+func buildVngCmdline(vngPath, BinCommand string, vmCfg *VMConfig) []string {
+	kernelVersion := vmCfg.KernelVersion
+	var vngArgs []string
+	if vmCfg.VngArgs != "" {
+		vngArgs = strings.Split(vmCfg.VngArgs, " ")
+	}
+	cmdline := []string{vngPath, "-r", kernelVersion}
+	cmdline = append(cmdline, vngArgs...)
+	cmdline = append(cmdline, "--", BinCommand)
+	return cmdline
+}
+
 // runVng executes the vng command for a specific kernel version and returns true if exit code is 0
-func runVng(ctx context.Context, vngPath, BinCommand, version string) result {
-	cmdline := []string{vngPath, "-r", version, "--", BinCommand}
+func runVng(ctx context.Context, vngPath, BinCommand string, vmCfg *VMConfig) result {
+	kernelVersion := vmCfg.KernelVersion
+	cmdline := buildVngCmdline(vngPath, BinCommand, vmCfg)
 	log.Infof("Running command `%v`\n", cmdline)
 	defer log.Infof("Command complete `%v`\n", cmdline)
 
@@ -70,15 +84,15 @@ func runVng(ctx context.Context, vngPath, BinCommand, version string) result {
 	cmd.Stderr = &stderrBuf
 	err := cmd.Run()
 	if err == nil {
-		return result{version: version, res: success, message: "Stdout:\n" + stdoutBuf.String()}
+		return result{version: kernelVersion, res: success, message: "Stdout:\n" + stdoutBuf.String()}
 	}
 
 	stderrStr := stderrBuf.String()
 	if strings.Contains(stderrStr, defaultMissingKernelVersion) || strings.Contains(stderrStr, defaultWrongFormat) {
-		return result{version: version, res: missing, message: "Stdout:\n" + stdoutBuf.String() + "\nStderr:\n" + stderrBuf.String()}
+		return result{version: kernelVersion, res: missing, message: "Stdout:\n" + stdoutBuf.String() + "\nStderr:\n" + stderrBuf.String()}
 	}
 
-	return result{version: version, res: failure, message: "Stdout:\n" + stdoutBuf.String() + "\nStderr:\n" + stderrBuf.String()}
+	return result{version: kernelVersion, res: failure, message: "Stdout:\n" + stdoutBuf.String() + "\nStderr:\n" + stderrBuf.String()}
 }
 
 func convertResToIcon(res code) string {
@@ -140,24 +154,24 @@ func run(cfg *Config) []result {
 	sem := make(chan struct{}, cfg.Parallel)
 	var wg sync.WaitGroup
 
-	results := make([]result, len(cfg.KernelVersions))
+	results := make([]result, len(cfg.VMConfigs))
 
-	// Launch vng commands concurrently for each kernel version
-	for i, ver := range cfg.KernelVersions {
+	// Launch vng commands concurrently for each VM configuration.
+	for i, vmCfg := range cfg.VMConfigs {
 		select {
 		case <-ctx.Done():
-			results[i] = result{version: ver, res: cancelled, message: "Cancelled"}
+			results[i] = result{version: vmCfg.KernelVersion, res: cancelled, message: "Cancelled"}
 			continue
 		default:
 		}
 
 		wg.Add(1)
 		sem <- struct{}{}
-		go func(idx int, version string) {
+		go func(idx int, vmCfg *VMConfig) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			results[idx] = runVng(ctx, cfg.VngPath, cfg.Cmd, version)
-		}(i, ver)
+			results[idx] = runVng(ctx, cfg.VngPath, cfg.Cmd, vmCfg)
+		}(i, &vmCfg)
 	}
 
 	wg.Wait()

--- a/main_test.go
+++ b/main_test.go
@@ -21,11 +21,15 @@ import (
 )
 
 func defaultConfig(versions []string, successBinary bool) *Config {
+	vmCfgs := make([]VMConfig, 0, len(versions))
+	for _, version := range versions {
+		vmCfgs = append(vmCfgs, VMConfig{KernelVersion: version})
+	}
 	cfg := &Config{
-		KernelVersions: versions,
-		OutPath:        "",
-		VngPath:        "vng",
-		Parallel:       1,
+		VMConfigs: vmCfgs,
+		OutPath:   "",
+		VngPath:   "vng",
+		Parallel:  1,
 	}
 	if successBinary {
 		cfg.Cmd = "/usr/bin/true"


### PR DESCRIPTION
This PR replaces `kernel_versions` key in the YAML config with a generic `instance_configs`. `instance_configs` is now a list where each element can be either a string or an object:
- a string is interpreted as a kernel version
- an object is parsed as an `InstanceConfig` struct, and can specify, besides the kernel version, arguments to be provided to vng (e.g.: "--memory 2G")

It keeps `--kernel_versions` CLI flags in order to not make the CLI interface too complex.

The following is an example of how a "mixed" instances configuration could look like:
```YAML
...
instance_configs:
  - v5.4.293
  - kernel_version: v5.10.237
    vng_args: "--memory 2G"
  - v5.15.182
```

I used the word "instance" because I couldn't find a better name. Happy to change it with some more appropriate term.

This partially addresses https://github.com/Andreagit97/bpfvalidator/issues/14, but doesn't implement support for fetching kernel from custom places.

The need for this change from https://github.com/falcosecurity/libs/pull/2908#issuecomment-4097186925